### PR TITLE
feat: Update build workflow and translate step names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
           dotnet-version: "9.0.x"
 
       - name: NuGet パッケージの復元
-        run: dotnet restore ./${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
+        run: |
+          dotnet restore ./${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
+          dotnet restore ./${{ env.PROJECT_NAME }}.Tests/${{ env.PROJECT_NAME }}.Tests.csproj
 
       - name: テストの実行
         run: dotnet test ./${{ env.PROJECT_NAME }}.Tests/${{ env.PROJECT_NAME }}.Tests.csproj --configuration Release --no-restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,10 @@ jobs:
       - name: NuGet パッケージの復元
         run: dotnet restore ./${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
 
-      - name: アプリケーションのビルド(Release)
+      - name: テストの実行
+        run: dotnet test ./${{ env.PROJECT_NAME }}.Tests/${{ env.PROJECT_NAME }}.Tests.csproj --configuration Release --no-restore
+
+      - name: アプリケーションのビルド (Release)
         run: dotnet build ./${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj --configuration Release --no-restore
 
       - name: 成果物のアップロード


### PR DESCRIPTION
- Translates all step names in build.yml to Japanese.
- Moves the test execution step to run before the main application build.
- Adjusts the test command to `dotnet test --configuration Release --no-restore` for the test project, allowing it to build itself if necessary before the main project build.

Addresses your feedback regarding step naming, execution order, and branch name.